### PR TITLE
Allow gcloud command to run without exiting tests

### DIFF
--- a/infra/scripts/test-end-to-end.sh
+++ b/infra/scripts/test-end-to-end.sh
@@ -90,6 +90,7 @@ ORIGINAL_DIR=$(pwd)
 cd tests/e2e
 
 set +e
+export GOOGLE_APPLICATION_CREDENTIALS=/etc/gcloud/service-account.json
 pytest redis/* --enable_auth=${ENABLE_AUTH} --junitxml=${LOGS_ARTIFACT_PATH}/python-sdk-test-report.xml
 TEST_EXIT_CODE=$?
 

--- a/sdk/python/feast/grpc/auth.py
+++ b/sdk/python/feast/grpc/auth.py
@@ -193,15 +193,15 @@ class GoogleOpenIDAuthMetadataPlugin(grpc.AuthMetadataPlugin):
         from google.auth import jwt
         import subprocess
 
-        cli_output = subprocess.run(
-            ["gcloud", "auth", "print-identity-token"], stdout=subprocess.PIPE
-        )
-        token = cli_output.stdout.decode("utf-8").strip()
         try:
+            cli_output = subprocess.run(
+                ["gcloud", "auth", "print-identity-token"], stdout=subprocess.PIPE
+            )
+            token = cli_output.stdout.decode("utf-8").strip()
             jwt.decode(token, verify=False)  # Ensure the token is valid
             self._token = token
             return
-        except ValueError:
+        except (ValueError, FileNotFoundError):
             pass  # GCloud command not successful
 
         # Try to use Google Auth library to find ID Token
@@ -218,10 +218,9 @@ class GoogleOpenIDAuthMetadataPlugin(grpc.AuthMetadataPlugin):
 
         # Raise exception otherwise
         raise RuntimeError(
-            "Could not determine Google ID token. Please ensure that the "
-            "Google Cloud SDK is installed or that a service account can be "
-            "found using the GOOGLE_APPLICATION_CREDENTIALS environmental "
-            "variable."
+            "Could not determine Google ID token. Please ensure that the Google Cloud SDK is installed and run: "
+            "\"gcloud auth application-default login\" or ensure that a service account can be found by setting"
+            " the GOOGLE_APPLICATION_CREDENTIALS environmental variable to its path."
         )
 
     def set_static_token(self, token):


### PR DESCRIPTION
This should allow the command to run without failure.